### PR TITLE
Update code base to 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - release
+#  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
-StatsBase
-LearnBase
-MappedArrays
+julia 0.6-
+StatsBase 0.13
+LearnBase 0.1.3 0.2.0
+MappedArrays 0.0.6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+#  - JULIAVERSION: "julialang/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+#  - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/MLLabelUtils.jl
+++ b/src/MLLabelUtils.jl
@@ -44,4 +44,3 @@ include("convertlabel.jl")
 include("labelmap.jl")
 
 end # module
-

--- a/src/classify.jl
+++ b/src/classify.jl
@@ -117,4 +117,3 @@ function classify!{R<:Number,T<:LabelEnc.OneOfK}(buffer::AbstractVector, values:
     end
     buffer
 end
-

--- a/src/labelencoding.jl
+++ b/src/labelencoding.jl
@@ -38,9 +38,9 @@ module LabelEnc
     """
     immutable ZeroOne{T<:Number,R<:Number} <: BinaryLabelEncoding{T,1}
         cutoff::R
-        function ZeroOne(cutoff::R = R(0.5))
+        function (::Type{ZeroOne{T,R}}){T,R}(cutoff::R = R(0.5))
             @assert 0 <= cutoff <= 1
-            new(cutoff)
+            new{T,R}(cutoff)
         end
     end
     ZeroOne{T<:Number,R<:Number}(t::Type{T} = Float64, cutoff::R = 0.5) = ZeroOne{T,R}(cutoff)
@@ -93,9 +93,9 @@ module LabelEnc
     `T(2)` corresponds to the negative class.
     """
     immutable Indices{T<:Number,K} <: LabelEncoding{T,K,1}
-        function Indices()
+        function (::Type{Indices{T,K}}){T,K}()
             typeof(K) <: Int || throw(TypeError(:Indices,"constructor when checking typeof(K)",Type{Int},typeof(K)))
-            new()
+            new{T,K}()
         end
     end
     Indices{T,K}(::Type{T}, ::Type{Val{K}}) = Indices{T,K}()
@@ -113,9 +113,9 @@ module LabelEnc
     `K` elements is set to 1.
     """
     immutable OneOfK{T<:Number,K} <: LabelEncoding{T,K,2}
-        function OneOfK()
+        function (::Type{OneOfK{T,K}}){T,K}()
             typeof(K) <: Int || throw(TypeError(:OneOfK,"constructor when checking typeof(K)",Type{Int},typeof(K)))
-            new()
+            new{T,K}()
         end
     end
     OneOfK{T,K}(::Type{T}, ::Type{Val{K}}) = OneOfK{T,K}()
@@ -139,10 +139,10 @@ module LabelEnc
     immutable NativeLabels{T,K} <: LabelEncoding{T,K,1}
         label::Vector{T}
         invlabel::Dict{T,Int}
-        function NativeLabels(label::Vector{T})
+        function (::Type{NativeLabels{T,K}}){T,K}(label::Vector{T})
             typeof(K) <: Int || throw(TypeError(:NativeLabels,"constructor when checking typeof(K)",Type{Int},typeof(K)))
             @assert length(label) == length(unique(label)) == K
-            new(label, Dict(zip(label,1:K)))
+            new{T,K}(label, Dict(zip(label,1:K)))
         end
     end
     NativeLabels{T,K}(label::Vector{T}, ::Type{Val{K}}) = NativeLabels{T,K}(label)

--- a/src/labelmap.jl
+++ b/src/labelmap.jl
@@ -60,4 +60,3 @@ labelfreq(A::AbstractMatrix) = throw(ArgumentError("labelfreq not supported for 
 labelenc(x::Dict) = labelenc(label(x))
 nlabel(x::Dict) = length(keys(x))
 label(x::Dict) = _arrange_label(collect(keys(x)))
-

--- a/src/learnbase.jl
+++ b/src/learnbase.jl
@@ -1,15 +1,10 @@
 # everything that should move to learnbase
 
-abstract LabelEncoding{T,K,M} # Eltype, Labelcount, Arraydimensions
-typealias BinaryLabelEncoding{T,M} LabelEncoding{T,2,M}
-typealias VectorLabelEncoding{T,K} LabelEncoding{T,K,1}
-typealias MatrixLabelEncoding{T,K} LabelEncoding{T,K,2}
-
-Base.size(::LabelEncoding) = ()
-Base.getindex(lm::LabelEncoding, idx) = lm
-
-Base.size{T<:LabelEncoding}(::Type{T}) = ()
-Base.getindex{T<:LabelEncoding}(t::Type{T}, idx) = t
+# Eltype, Labelcount, Arraydimensions
+abstract type LabelEncoding{T,K,M} end
+const BinaryLabelEncoding{T,M} = LabelEncoding{T,2,M}
+const VectorLabelEncoding{T,K} = LabelEncoding{T,K,1}
+const MatrixLabelEncoding{T,K} = LabelEncoding{T,K,2}
 
 """
     nlabel(obj) -> Int
@@ -364,4 +359,3 @@ frequencies for each label in `obj`
       1 => 3
 """
 function labelfreq! end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,4 +13,3 @@ for t in tests
         include(t)
     end
 end
-

--- a/test/tst_classify.jl
+++ b/test/tst_classify.jl
@@ -136,4 +136,3 @@ end
         @test buffer == [1,3,2,1,2,3,2]
     end
 end
-

--- a/test/tst_convertlabel.jl
+++ b/test/tst_convertlabel.jl
@@ -59,6 +59,8 @@ _dst_eltype(::Type{Bool}, default) = default
     end
 end
 
+println("<HEARTBEAT>")
+
 @testset "convertlabelview multiclass" begin
     for (src_lm, src_x) in (
             (LabelEnc.Indices(Int32,3),Int32[1,2,3,2,2,1]),
@@ -86,13 +88,15 @@ end
     end
 end
 
+println("<HEARTBEAT>")
+
 @testset "convert binary" begin
     @test convertlabel(LabelEnc.MarginBased, UInt8[1,0,1], LabelEnc.ZeroOne()) == [0x1,0xff,0x1]
     for (src_lm, src_x) in (
             (LabelEnc.FuzzyBinary(),Any[true,0,1,-1,false,3]),
             (LabelEnc.FuzzyBinary(),Int32[1,0,1,0,0,1]),
             (LabelEnc.FuzzyBinary(),Float64[1,-1,1,-1,-1,1]),
-            (LabelEnc.TrueFalse(),[true,false,true,false,false,true]),
+            (LabelEnc.TrueFalse(),BitArray([true,false,true,false,false,true])),
             (LabelEnc.ZeroOne(),Int32[1,0,1,0,0,1]),
             (LabelEnc.ZeroOne(),Int64[1,0,1,0,0,1]),
             (LabelEnc.ZeroOne(),Float32[1,0,1,0,0,1]),
@@ -105,12 +109,12 @@ end
             (LabelEnc.OneVsRest(:yes),[:yes,:no,:yes,:maybe,:no,:yes]),
             (LabelEnc.NativeLabels([:a,:b]),[:a,:b,:a,:b,:b,:a]),
             ([:a,:b],[:a,:b,:a,:b,:b,:a]),
-            (LabelEnc.OneOfK(Bool,2),Bool[1 0 1 0 0 1; 0 1 0 1 1 0]),
+            (LabelEnc.OneOfK(Bool,2),BitArray(Bool[1 0 1 0 0 1; 0 1 0 1 1 0])),
             (LabelEnc.OneOfK(Int8,2),Int8[1 0 1 0 0 1; 0 1 0 1 1 0]),
         )
         for (dst_lm, dst_x) in (
-                (LabelEnc.TrueFalse,[true,false,true,false,false,true]),
-                (LabelEnc.TrueFalse(),[true,false,true,false,false,true]),
+                (LabelEnc.TrueFalse,BitArray([true,false,true,false,false,true])),
+                (LabelEnc.TrueFalse(),BitArray([true,false,true,false,false,true])),
                 (LabelEnc.ZeroOne,(_dst_eltype(eltype(src_x),Float64))[1,0,1,0,0,1]),
                 (LabelEnc.ZeroOne(UInt8),UInt8[1,0,1,0,0,1]),
                 (LabelEnc.ZeroOne(Int),Int[1,0,1,0,0,1]),
@@ -129,14 +133,14 @@ end
                 (LabelEnc.OneOfK,(_dst_eltype(eltype(src_x),Int))[1 0 1 0 0 1; 0 1 0 1 1 0]),
                 (LabelEnc.OneOfK{UInt8},UInt8[1 0 1 0 0 1; 0 1 0 1 1 0]),
                 (LabelEnc.OneOfK{Float32},Float32[1 0 1 0 0 1; 0 1 0 1 1 0]),
-                (LabelEnc.OneOfK(Bool,2),Bool[1 0 1 0 0 1; 0 1 0 1 1 0]),
+                (LabelEnc.OneOfK(Bool,2),BitArray(Bool[1 0 1 0 0 1; 0 1 0 1 1 0])),
             )
             @testset "($src_lm) $src_x -> ($dst_lm) $dst_x" begin
                 if !(typeof(dst_lm) <: Vector)
                     @test @inferred(islabelenc(dst_x, dst_lm)) == true
                 end
-                if !(typeof(src_lm)<:LabelEnc.FuzzyBinary) && !((typeof(src_lm) <: LabelEnc.OneVsRest)$(typeof(dst_lm) <: LabelEnc.OneVsRest))
-                    res = if typeof(dst_lm) <: DataType || typeof(dst_lm) <: Array
+                if !(typeof(src_lm)<:LabelEnc.FuzzyBinary) && !xor((typeof(src_lm) <: LabelEnc.OneVsRest),(typeof(dst_lm) <: LabelEnc.OneVsRest))
+                    res = if typeof(dst_lm) <: Type || typeof(dst_lm) <: Array
                         convertlabel(dst_lm, src_x)
                     else
                         @inferred convertlabel(dst_lm, src_x)
@@ -144,7 +148,7 @@ end
                     @test typeof(res) <: typeof(dst_x)
                     @test res == dst_x
                 end
-                res = if typeof(src_lm) <: Vector && typeof(dst_lm) <: DataType && (dst_lm <: LabelEnc.Indices || dst_lm <: LabelEnc.OneOfK)
+                res = if typeof(src_lm) <: Vector && typeof(dst_lm) <: Type && (dst_lm <: LabelEnc.Indices || dst_lm <: LabelEnc.OneOfK)
                     # in this situation K can not be inferred
                     # this is because we neither specify in src or dst the number of labels at compile time
                     convertlabel(dst_lm, src_x, src_lm)
@@ -158,6 +162,7 @@ end
                 @test res == dst_x
             end
         end
+        println("<HEARTBEAT>")
     end
 end
 
@@ -167,7 +172,7 @@ end
             (LabelEnc.Indices(Float64,3),Float64[1,2,3,2,3,1]),
             (LabelEnc.NativeLabels([:a,:b,:c]),[:a,:b,:c,:b,:c,:a]),
             ([:a,:b,:c],[:a,:b,:c,:b,:c,:a]),
-            (LabelEnc.OneOfK(Bool,3),Bool[1 0 0 0 0 1; 0 1 0 1 0 0; 0 0 1 0 1 0]),
+            (LabelEnc.OneOfK(Bool,3),BitArray(Bool[1 0 0 0 0 1; 0 1 0 1 0 0; 0 0 1 0 1 0])),
             (LabelEnc.OneOfK(Int8,3),Int8[1 0 0 0 0 1; 0 1 0 1 0 0; 0 0 1 0 1 0]),
         )
         for (dst_lm, dst_x) in (
@@ -180,20 +185,20 @@ end
                 (LabelEnc.OneOfK,(_dst_eltype(eltype(src_x),Int))[1 0 0 0 0 1; 0 1 0 1 0 0; 0 0 1 0 1 0]),
                 (LabelEnc.OneOfK{UInt8},UInt8[1 0 0 0 0 1; 0 1 0 1 0 0; 0 0 1 0 1 0]),
                 (LabelEnc.OneOfK{Float32},Float32[1 0 0 0 0 1; 0 1 0 1 0 0; 0 0 1 0 1 0]),
-                (LabelEnc.OneOfK(Bool,3),Bool[1 0 0 0 0 1; 0 1 0 1 0 0; 0 0 1 0 1 0]),
+                (LabelEnc.OneOfK(Bool,3),BitArray(Bool[1 0 0 0 0 1; 0 1 0 1 0 0; 0 0 1 0 1 0])),
             )
             @testset "($src_lm) $src_x -> ($dst_lm) $dst_x" begin
                 if !(typeof(dst_lm) <: Vector)
                     @test @inferred(islabelenc(dst_x, dst_lm)) == true
                 end
-                res = if typeof(dst_lm) <: DataType || typeof(dst_lm) <: Array
+                res = if typeof(dst_lm) <: Type || typeof(dst_lm) <: Array
                     convertlabel(dst_lm, src_x)
                 else
                     @inferred convertlabel(dst_lm, src_x)
                 end
                 @test typeof(res) <: typeof(dst_x)
                 @test res == dst_x
-                res = if typeof(src_lm) <: Vector && typeof(dst_lm) <: DataType && (dst_lm <: LabelEnc.Indices || dst_lm <: LabelEnc.OneOfK)
+                res = if typeof(src_lm) <: Vector && typeof(dst_lm) <: Type && (dst_lm <: LabelEnc.Indices || dst_lm <: LabelEnc.OneOfK)
                     # in this situation K can not be inferred
                     # this is because we neither specify in src or dst the number of labels at compile time
                     convertlabel(dst_lm, src_x, src_lm)
@@ -210,13 +215,15 @@ end
     end
 end
 
+println("<HEARTBEAT>")
+
 @testset "binary OneOfK with and without ObsDim" begin
     x = [1 0 1 0 0 1; 0 1 0 1 1 0]
     xt = x'
     # From OneOfK
     for (dst_lm, dst_x) in (
-            (LabelEnc.TrueFalse,[true,false,true,false,false,true]),
-            (LabelEnc.TrueFalse(),[true,false,true,false,false,true]),
+            (LabelEnc.TrueFalse,BitArray([true,false,true,false,false,true])),
+            (LabelEnc.TrueFalse(),BitArray([true,false,true,false,false,true])),
             (LabelEnc.ZeroOne,(_dst_eltype(eltype(x),Float64))[1,0,1,0,0,1]),
             (LabelEnc.ZeroOne(UInt8),UInt8[1,0,1,0,0,1]),
             (LabelEnc.ZeroOne(Int),Int[1,0,1,0,0,1]),
@@ -234,7 +241,7 @@ end
             ([:a,:b],[:a,:b,:a,:b,:b,:a]),
         )
         @testset "$x -> ($dst_lm) $dst_x" begin
-            res = if typeof(dst_lm) <: DataType && (dst_lm <: LabelEnc.Indices || dst_lm <: LabelEnc.OneOfK)
+            res = if typeof(dst_lm) <: Type && (dst_lm <: LabelEnc.Indices || dst_lm <: LabelEnc.OneOfK)
                 convertlabel(dst_lm, x)
             else
                 @inferred convertlabel(dst_lm, x)
@@ -272,9 +279,10 @@ end
             @test res == dst_x
         end
     end
+    println("<HEARTBEAT>")
     # To OneOfK
     for (src_lm, src_x) in (
-            (LabelEnc.TrueFalse(),[true,false,true,false,false,true]),
+            (LabelEnc.TrueFalse(),BitArray([true,false,true,false,false,true])),
             (LabelEnc.ZeroOne(UInt8),UInt8[1,0,1,0,0,1]),
             (LabelEnc.ZeroOne(Int),Int[1,0,1,0,0,1]),
             (LabelEnc.ZeroOne(),[1.,0,1,0,0,1]),
@@ -289,7 +297,7 @@ end
         for (dst_lm, dst_x) in (
                 (LabelEnc.OneOfK,Array{(_dst_eltype(eltype(src_x),Int))}(x)),
                 (LabelEnc.OneOfK{Float32},Array{Float32}(x)),
-                (LabelEnc.OneOfK(Bool,2),Array{Bool}(x)),
+                (LabelEnc.OneOfK(Bool,2),BitArray(x)),
              )
             @testset "($src_lm) $src_x -> ($dst_lm) $dst_x" begin
                 res = @inferred convertlabel(dst_lm, src_x, src_lm)
@@ -325,6 +333,8 @@ end
     end
 end
 
+println("<HEARTBEAT>")
+
 @testset "multiclass OneOfK with and without ObsDim" begin
     x = [1 0 0 0 0 1; 0 1 0 1 0 0; 0 0 1 0 1 0]
     xt = x'
@@ -336,7 +346,7 @@ end
             ([:a,:b,:c],[:a,:b,:c,:b,:c,:a]),
         )
         @testset "$x -> ($dst_lm) $dst_x" begin
-            res = if typeof(dst_lm) <: DataType && (dst_lm <: LabelEnc.Indices || dst_lm <: LabelEnc.OneOfK)
+            res = if typeof(dst_lm) <: Type && (dst_lm <: LabelEnc.Indices || dst_lm <: LabelEnc.OneOfK)
                 convertlabel(dst_lm, x)
             else
                 @inferred convertlabel(dst_lm, x)
@@ -397,7 +407,7 @@ end
         for (dst_lm, dst_x) in (
                 (LabelEnc.OneOfK,Array{(_dst_eltype(eltype(src_x),Int))}(x)),
                 (LabelEnc.OneOfK{Float32},Array{Float32}(x)),
-                (LabelEnc.OneOfK(Bool,3),Array{Bool}(x)),
+                (LabelEnc.OneOfK(Bool,3),BitArray(x)),
              )
             @testset "($src_lm) $src_x -> ($dst_lm) $dst_x" begin
                 res = @inferred convertlabel(dst_lm, src_x, src_lm)
@@ -432,4 +442,3 @@ end
         end
     end
 end
-

--- a/test/tst_labelmap.jl
+++ b/test/tst_labelmap.jl
@@ -133,4 +133,3 @@ end
         @test lm[2] == 2
     end
 end
-


### PR DESCRIPTION
Supporting both versions is too much effort given the `BitArray` changes in 0.6.
This PR makes the full move to 0.6 and onwards.