### PR TITLE
use 0.6.0-pre as minimum julia version in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 StatsBase 0.13
 LearnBase 0.1.5 0.2.0
 MappedArrays 0.0.6


### PR DESCRIPTION
since `abstract type` syntax wouldn't work on early 0.6.0-dev versions,
better to stick with julia-0.5-compatible versions of the package there