### PR TITLE
add NativeLabels example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,17 +246,18 @@ julia> classify([0.1,0.2,0.6,0.1], LabelEnc.OneOfK) # single observation
 ```
 
 
-`NativeLabels` maps between data of an arbitary type (e.g. Strings) and an integer index:
+`NativeLabels` maps between data of an arbitary type (e.g. Strings) and the other label types (Normally `LabelEnc.Indices{Int}` for an integer index).
+When using it, you should always save the encoding in a variable, and pass it as an argument to `convertlabel`;
+as otherwise the encoding will be inferred each time, so will normally encode differently for different inputs.
 
 ```julia
-julia> enc = labelenc(["a", "b", "c", "d"])
-MLLabelUtils.LabelEnc.NativeLabels{String,4}(String["a", "b", "c", "d"], Dict("c"=>3,"b"=>2,"a"=>1,"d"=>4))
+julia> enc = labelenc(["copper", "tin", "gold"])
+MLLabelUtils.LabelEnc.NativeLabels{String,3}(String["copper", "tin", "gold"], Dict("gold"=>3,"copper"=>1,"tin"=>2))
 
-julia> ind2label(3, enc)
-"c"
-
-julia> label2ind("c", enc)
-3
+julia> convertlabel(LabelEnc.Indices, ["gold", "copper"], enc)
+2-element Array{Int64,1}:
+ 3
+ 1
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -245,6 +245,20 @@ julia> classify([0.1,0.2,0.6,0.1], LabelEnc.OneOfK) # single observation
 # 3
 ```
 
+
+`NativeLabels` maps between data of an arbitary type (e.g. Strings) and an integer index:
+
+```julia
+julia> enc = labelenc(["a", "b", "c", "d"])
+MLLabelUtils.LabelEnc.NativeLabels{String,4}(String["a", "b", "c", "d"], Dict("c"=>3,"b"=>2,"a"=>1,"d"=>4))
+
+julia> ind2label(3, enc)
+"c"
+
+julia> label2ind("c", enc)
+3
+```
+
 ## Documentation
 
 For a much more detailed treatment check out the


### PR DESCRIPTION
All the other label types have an example.
And I always forget what the command for `ind2label` and `label2ind` is.
It is in the docs, but everything else has a quick example in the readme