### PR TITLE
relax type constraints on convertlabel

### DIFF
--- a/src/convertlabel.jl
+++ b/src/convertlabel.jl
@@ -53,7 +53,7 @@ end
 
 ## Generic types to objects
 
-function convertlabel(::Type{L}, x::T, src::LabelEncoding{T,K}) where {L<:LabelEncoding,T,K}
+function convertlabel(::Type{L}, x, src::LabelEncoding{T,K}) where {L<:LabelEncoding,T,K}
     convertlabel(_lm(L,Val{K}), x, src)
 end
 

--- a/test/tst_convertlabel.jl
+++ b/test/tst_convertlabel.jl
@@ -443,7 +443,10 @@ println("<HEARTBEAT>")
     end
 end
 
-@testset "special examples" begin
+@testset "special NativeLabels-Indices examples" begin
     enc = LabelEnc.NativeLabels(["a","b","c","d"])
     @test @inferred(convertlabel(LabelEnc.Indices, "c", enc)) == 3
+
+    csub = SubString("c",1,1)
+    @test @inferred(convertlabel(LabelEnc.Indices, csub, enc)) == 3
 end


### PR DESCRIPTION
The constraint was too tight, and stopped `SubStrings` being treated as equal to `Strings`

This is related to https://github.com/JuliaML/MLLabelUtils.jl/issues/10
but is for the user-facing `convertlabel`