### PR TITLE
Add a fallback option to NativeLabels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# v0.3.0
+ - Allow `NativeLavels` to specify a fallback label function to be used if 
+   an label that is not known to the encoder is encountered.
+
 # v0.2.0
 
 - drop `0.6.0-pre` and update syntax to `0.6`

--- a/src/labelencoding.jl
+++ b/src/labelencoding.jl
@@ -149,10 +149,33 @@ module LabelEnc
 
     Represents arbitrary class labels by storing the possible values
     as a member variable.
+    
+    Constructor `LabelEnc.NativeLabels([fallbacklabel], classlabels)`
+     - `classlabels` is a collection of labels that are allowed by the
+       encoding. Each one representing a class.
+     - `fallbacklabel` is an optional first argument.
+         - It is either:
+            - a value from `classlabels` which is used to encode any observed
+              label that does not occur in `classlabels`
+            - or; a function which takes as its input a label which does not 
+              occur in `classlabels` and returns one that does.
+         - This can be used for example to handle out of vocabulary words in NLP 
+           as in `LabelEnc.NativeLabels("<OOV>", [red", "green", blue", ..., "<OOV>"])`
+         - Or to standardize inputs: as in 
+           ```
+            LabelEnc.NativeLabels([..., v"0.5.2", v"0.6.0", v"0.6.1", ....]) do oov
+                # Discard build and prerelease fields, `v"0.7.0-beta.18"`->`v"0.7.0"`
+                VersionNumber(oov.major, oov.minor, oov.patch)
+            end
+           ```
+
 
     In a binary setting the first element of the stored class labels
     represents the positive label and the second element the negative
     label.
+    In a multiclass setting, the labels will `convertenc` to 
+    `LabelEnc.Indices`  using their position in the `label` argument 
+    to the constructor.
     """
     struct NativeLabels{T,K,F} <: LabelEncoding{T,K,1}
         getfallbacklabel::F


### PR DESCRIPTION
This is my attempt to fix #21 
This isn't quiet done. It has no docs.
I wanted to get feedback on it before I spent more time though.

It works and it passes tests. But no docs, and I am not sure this is the best way to do it.
It is missing a little test coverage on the `with_fallbacklabel` because I'm not sure if they are  a good idea at all.
I just stuck them in to discuss them, and if something like that is needed.

Right now the only way to create a NativeLabels encoding with a fallback is via the constructor.
But as per https://github.com/JuliaML/MLLabelUtils.jl/pull/17#discussion_r186635652
that is often the correct way to create NativeLabelsEncodings anyway.
I added `with_fallbacklabel` which takes a encoding and a fallback, and adds it to it,
so that if you are defining the NativeLabels encoding using `labelenc` then you can add the fallback after the fact.
