### PR TITLE
Add labelmap2vec.

### DIFF
--- a/docs/api/targets.rst
+++ b/docs/api/targets.rst
@@ -394,6 +394,34 @@ observation(s).
      :maybe => [4,8]
      :no    => [2,3,6,7]
 
+There also is a convenience function to reverse a labelmap into a label vector.
+
+.. function:: labelmap2vec(dict) -> Vector
+
+Computes an `Vector` of labels by element-wise
+traversal of the entries in `dict`.
+
+   :param Dict{T, Int} dict: A labelmap with labels of type T.
+
+   :return: Vector{T} of labels.
+
+.. code-block:: jlcon
+
+   julia> labelvec = [:yes,:no,:no,:yes,:yes]
+
+   julia> lm = labelmap(labelvec)
+   Dict{Symbol,Array{Int64,1}} with 2 entries:
+       :yes => [1, 4, 5]
+       :no  => [2, 3]
+
+   julia> labelmap2vec(lm)
+   5-element Array{Symbol,1}:
+       :yes
+       :no
+       :no
+       :yes
+       :yes
+
 Frequency of Labels
 ------------------------
 
@@ -491,4 +519,3 @@ frequency-map in-place.
      :yes   => 2
      :maybe => 2
      :no    => 4
-

--- a/src/MLLabelUtils.jl
+++ b/src/MLLabelUtils.jl
@@ -31,6 +31,7 @@ export
     labelmap!,
     labelfreq,
     labelfreq!,
+    labelmap2vec,
 
     LabelEnc,
     labelenc,

--- a/src/labelmap.jl
+++ b/src/labelmap.jl
@@ -60,3 +60,14 @@ labelfreq(A::AbstractMatrix) = throw(ArgumentError("labelfreq not supported for 
 labelenc(x::Dict) = labelenc(label(x))
 nlabel(x::Dict) = length(keys(x))
 label(x::Dict) = _arrange_label(collect(keys(x)))
+
+## Convert label map to label vector
+
+function labelmap2vec(lm::Dict{T, Vector{Int}}) where T
+    isempty(lm) && return Vector{T}(undef, 0)
+    labelvec = Vector{T}(undef, mapreduce(length, +, values(lm)))
+    @inbounds for (k, v) in lm
+        labelvec[v] .= k
+    end
+    return labelvec
+end

--- a/src/learnbase.jl
+++ b/src/learnbase.jl
@@ -361,3 +361,27 @@ frequencies for each label in `obj`
       1 => 3
 """
 function labelfreq! end
+
+"""
+    labelmap2vec(dict) -> Vector
+
+Inverse function of labelmap.
+Computes an `array` of labels by element-wise
+traversal of the entries in `dict`.
+
+    julia> labelvec = [:yes,:no,:no,:yes,:yes]
+
+    julia> lm = labelmap(labelvec)
+    Dict{Symbol,Array{Int64,1}} with 2 entries:
+        :yes => [1, 4, 5]
+        :no  => [2, 3]
+
+    julia> labelmap2vec(lm)
+    5-element Array{Symbol,1}:
+        :yes
+        :no
+        :no
+        :yes
+        :yes
+"""
+function labelmap end

--- a/test/tst_labelmap.jl
+++ b/test/tst_labelmap.jl
@@ -132,4 +132,20 @@ end
         @test lm[-1] == 2
         @test lm[2] == 2
     end
+
+    @testset "labelmap2vec" begin
+        @testset "Symbol" begin
+            labelvec = [:yes,:no,:no,:yes,:yes]
+            @test labelvec == @inferred labelmap2vec(labelmap(labelvec))
+            labelvec = Vector{Symbol}(undef, 0)
+            @test labelvec == @inferred labelmap2vec(labelmap(labelvec))
+        end
+
+        @testset "Float64" begin
+            labelvec = [1.,-1,-1,1,1]
+            @test labelvec == @inferred labelmap2vec(labelmap(labelvec))
+            labelvec = Vector{Float64}(undef, 0)
+            @test labelvec == @inferred labelmap2vec(labelmap(labelvec))
+        end
+    end
 end


### PR DESCRIPTION
This adds functionality to convert a labelmap into a label vector.

Example:

```julia
julia> labelvec = [:yes,:no,:no,:yes,:yes]
5-element Array{Symbol,1}:
 :yes
 :no
 :no
 :yes
 :yes

julia> lm = labelmap(labelvec)
Dict{Symbol,Array{Int64,1}} with 2 entries:
  :yes => [1, 4, 5]
  :no  => [2, 3]

julia> labelmap2vec(lm)
5-element Array{Symbol,1}:
 :yes
 :no
 :no
 :yes
 :yes

```