### PR TITLE
Fix docs warning during testing.

### DIFF
--- a/src/learnbase.jl
+++ b/src/learnbase.jl
@@ -384,4 +384,4 @@ traversal of the entries in `dict`.
         :yes
         :yes
 """
-function labelmap end
+function labelmap2vec end


### PR DESCRIPTION
Currently there is warning when the `MLLabelUtils` package is installed:
```
┌ Warning: Replacing docs for `MLLabelUtils.labelmap :: Union{}` in module `MLLabelUtils`
└ @ Base.Docs docs/Docs.jl:223
```
https://travis-ci.org/JuliaML/MLLabelUtils.jl/jobs/456938486#L519

This warning is also printed when packages are tested that depend on `MLLabelUtils`, e.g.:
https://travis-ci.com/englhardt/OneClassActiveLearning.jl/jobs/169461145#L580

This PR fixes this issue by adjusting the doc string for `labelmap2vec`.