### PR TITLE
Adds LearnBase 0.4 compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ MappedArrays = "dbb5928d-eab1-5f90-85c2-b9b0edb7c900"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-LearnBase = "0.2, 0.3"
+LearnBase = "0.2, 0.3, 0.4"
 MappedArrays = "0.2"
 StatsBase = "0.25, 0.26, 0.27, 0.28, 0.29, 0.30, 0.31, 0.32, 0.33"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLLabelUtils"
 uuid = "66a33bbf-0c2b-5fc8-a008-9da813334f0a"
 authors = ["Christof Stocker <stocker.christof@gmail.com>"]
-version = "0.5.3"
+version = "0.5.4"
 
 [deps]
 LearnBase = "7f8f8fb0-2700-5f03-b4bd-41f8cfc144b6"

--- a/src/learnbase.jl
+++ b/src/learnbase.jl
@@ -1,5 +1,5 @@
 # everything that should move to learnbase
-
+import LearnBase: ObsDim
 # Eltype, Labelcount, Arraydimensions
 abstract type LabelEncoding{T,K,M} end
 # act as scalar in broadcast, see julia #18618


### PR DESCRIPTION
Due to refactoring in https://github.com/JuliaML/LearnBase.jl/compare/v0.3.0...v0.4.0 ObsDim stopped being exported.
This should allow to effectively merge #37 .
But it should be reviewed if it's correct.